### PR TITLE
Make _hashlib more generic

### DIFF
--- a/yakutils/_hashlib.py
+++ b/yakutils/_hashlib.py
@@ -1,24 +1,49 @@
 """This module contains boilerplate hashlib helpers."""
 import hashlib
 
-__all__ = ["md5", "sha1", "sha384", "sha3_384"]
+__all__ = ["md5", "sha1", "sha384", "sha3_384", "hash_any"]
 
 
-def md5(s):
-    """Compute the MD5 of a given string."""
-    return hashlib.md5(s.encode("utf-8")).hexdigest()
+def md5(obj):
+    """Compute the MD5 of the given object."""
+    if isinstance(obj, str):
+        return hashlib.md5(obj.encode("utf-8")).hexdigest()
+    return hashlib.md5(bytes(obj)).hexdigest()
 
 
-def sha1(s):
-    """Compute the SHA1 of a given string."""
-    return hashlib.sha1(s.encode("utf-8")).hexdigest()
+def sha1(obj):
+    """Compute the SHA1 of the given object."""
+    if isinstance(obj, str):
+        return hashlib.sha1(obj.encode("utf-8")).hexdigest()
+    return hashlib.sha1(bytes(obj)).hexdigest()
 
 
-def sha384(s):
-    """Compute the SHA384 of a given string."""
-    return hashlib.sha384(s.encode("utf-8")).hexdigest()
+def sha384(obj):
+    """Compute the SHA384 of the given object."""
+    if isinstance(obj, str):
+        return hashlib.sha384(obj.encode("utf-8")).hexdigest()
+    return hashlib.sha384(bytes(obj)).hexdigest()
 
 
-def sha3_384(s):
-    """Compute the SHA3 384 of a given string."""
-    return hashlib.sha3_384(s.encode("utf-8")).hexdigest()
+def sha3_384(obj):
+    """Compute the SHA3 384 of the given object."""
+    if isinstance(obj, str):
+        return hashlib.sha3_384(obj.encode("utf-8")).hexdigest()
+    return hashlib.sha3_384(bytes(obj)).hexdigest()
+
+
+def hash_any(obj, hasher):
+    """ If hasher is a string, return the hash of the obj as specified by hasher. If hasher is an instance of hashlib's
+     hashers, return the hash of the object from hasher. """
+    if isinstance(obj, str):
+        obj_bytes = obj.encode("utf-8")
+    else:
+        obj_bytes = bytes(obj)
+
+    if isinstance(hasher, str):
+        return hashlib.new(hasher, obj_bytes).hexdigest()
+    elif str(type(hasher)) == "<class '_hashlib.HASH'>":
+        hasher.update(obj_bytes)
+        return hasher.hexdigest()
+    else:
+        raise TypeError("hasher is not a ??")

--- a/yakutils/_hashlib.py
+++ b/yakutils/_hashlib.py
@@ -1,49 +1,79 @@
 """This module contains boilerplate hashlib helpers."""
 import hashlib
+from functools import singledispatch
 
 __all__ = ["md5", "sha1", "sha384", "sha3_384", "hash_any"]
 
 
 def md5(obj):
     """Compute the MD5 of the given object."""
-    if isinstance(obj, str):
-        return hashlib.md5(obj.encode("utf-8")).hexdigest()
-    return hashlib.md5(bytes(obj)).hexdigest()
+    return hash_consumer(obj, hashlib.md5())
 
 
 def sha1(obj):
     """Compute the SHA1 of the given object."""
-    if isinstance(obj, str):
-        return hashlib.sha1(obj.encode("utf-8")).hexdigest()
-    return hashlib.sha1(bytes(obj)).hexdigest()
+    return hash_consumer(obj, hashlib.sha1())
 
 
 def sha384(obj):
     """Compute the SHA384 of the given object."""
-    if isinstance(obj, str):
-        return hashlib.sha384(obj.encode("utf-8")).hexdigest()
-    return hashlib.sha384(bytes(obj)).hexdigest()
+    return hash_consumer(obj, hashlib.sha384())
 
 
 def sha3_384(obj):
     """Compute the SHA3 384 of the given object."""
-    if isinstance(obj, str):
-        return hashlib.sha3_384(obj.encode("utf-8")).hexdigest()
-    return hashlib.sha3_384(bytes(obj)).hexdigest()
+    return hash_consumer(obj, hashlib.sha3_384())
 
 
 def hash_any(obj, hasher):
     """ If hasher is a string, return the hash of the obj as specified by hasher. If hasher is an instance of hashlib's
      hashers, return the hash of the object from hasher. """
-    if isinstance(obj, str):
-        obj_bytes = obj.encode("utf-8")
-    else:
-        obj_bytes = bytes(obj)
 
     if isinstance(hasher, str):
-        return hashlib.new(hasher, obj_bytes).hexdigest()
-    elif str(type(hasher)) == "<class '_hashlib.HASH'>":
-        hasher.update(obj_bytes)
-        return hasher.hexdigest()
-    else:
+        hasher = hashlib.new(hasher)
+    elif str(type(hasher)) != "<class '_hashlib.HASH'>":
         raise TypeError("hasher is not a ??")
+
+    return hash_consumer(obj, hasher)
+
+
+def hash_consumer(obj, hasher):
+    """ Takes the given obj, and attempts to hash it using the hasher. """
+    for hashable in any_to_hash(obj):
+        hasher.update(bytes(hashable))
+    return hasher.hexdigest()
+
+
+@singledispatch
+def any_to_hash(obj):
+    for value in [a for a in dir(obj) if not callable(getattr(obj, a)) and not a.startswith("__")]:
+        for item in any_to_hash(getattr(obj, value)):
+            yield item
+
+    try:
+        obj_iter = iter(obj)
+        for sub_obj in obj_iter:
+            for item in any_to_hash(sub_obj):
+                yield item
+    except TypeError:
+        pass
+
+
+@any_to_hash.register(str)
+def _any_to_hash_str(obj):
+    yield obj.encode("utf-8")
+
+
+@any_to_hash.register(int)
+def _any_to_hash_int(obj):
+    yield obj
+
+
+@any_to_hash.register(bytes)
+def _any_to_hash_bytes(obj):
+    yield obj
+
+
+@any_to_hash.register(bytearray)
+def _any_to_hash_bytearray(obj):
+    yield obj

--- a/yakutils/_hashlib.py
+++ b/yakutils/_hashlib.py
@@ -32,7 +32,7 @@ def hash_any(obj, hasher):
     if isinstance(hasher, str):
         hasher = hashlib.new(hasher)
     elif str(type(hasher)) != "<class '_hashlib.HASH'>":
-        raise TypeError("hasher is not a ??")
+        raise TypeError("The given hasher object does not support hashing.")
 
     return hash_consumer(obj, hasher)
 


### PR DESCRIPTION
This adds support for hashing arbitrary objects, and it also allows the user to use hash_any to hash any object by specifying a hash algorithm or passing in a _hashlib.HASH object (eg. the user creates hashlib.sha1())